### PR TITLE
docs: populate .specify constitution to v1.0.0, update agent rules and PR workflow

### DIFF
--- a/.agent/rules/speckit-rules.md
+++ b/.agent/rules/speckit-rules.md
@@ -1,0 +1,23 @@
+---
+trigger: always_on
+---
+
+## Spec-Kit Context
+
+Before ANY spec-kit workflow (`/speckit.*`), you MUST load and respect:
+
+1. **Constitution**: `.specify/memory/constitution.md` — 7 binding principles with axiom traceability
+2. **Templates**: `.specify/templates/` — canonical formats for `spec.md`, `plan.md`, `tasks.md`
+3. **Axioms**: `docs/AXIOMS.md` — the 5 foundational truths (Σ.1–Σ.5)
+4. **Postulates**: `docs/POSTULATES.md` — three orders of derivations (Π.x.y)
+
+## Constitutional Compliance
+
+- All generated specs, plans, and tasks MUST comply with the constitution's Quality Gates
+- The `plan-template.md` Constitution Check gate (§30–34) MUST be filled before Phase 0
+- Test-first (Red-Green-Refactor) is NON-NEGOTIABLE per Principle III
+- ADRs are REQUIRED for new components, tech selections, and breaking changes per Principle IV
+
+## File References
+
+@.specify/*

--- a/.agent/workflows/pr.md
+++ b/.agent/workflows/pr.md
@@ -1,0 +1,47 @@
+---
+description: Push local changes to a GitHub PR using MCP
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Workflow
+
+1. **Identify the repo** — Run `git remote get-url origin` to extract the GitHub `owner/repo`.
+
+2. **Determine changed files** — Run `git status --porcelain` to list uncommitted/staged changes. If no changes exist, inform the user and stop.
+
+3. **Build a branch name** — Derive from the change context:
+   - Prefix: `docs/`, `feat/`, `fix/`, `chore/` based on change type
+   - Slug: 2–4 word kebab-case summary (e.g., `docs/populate-constitution`)
+   - If `$ARGUMENTS` specifies a branch name, use that instead.
+
+4. **Create the branch via MCP** — Use `create_branch` on the GitHub MCP server:
+   ```
+   owner: <owner>
+   repo: <repo>
+   branch: <branch-name>
+   ```
+
+5. **Push files via MCP** — Use `create_or_update_file` (single file) or `push_files` (multiple files) on the GitHub MCP server. Use a conventional commit message:
+   - Format: `<type>: <short description>`
+   - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`
+
+6. **Create the PR via MCP** — Use `create_pull_request`:
+   - `title`: Same as the commit message
+   - `body`: Include a Summary, Changes list, and any validation notes
+   - `head`: `<branch-name>`
+   - `base`: `main`
+
+7. **Report** — Output the PR URL and number to the user.
+
+## Notes
+
+- All Git operations for reading state (remote URL, status) use the terminal.
+- All write operations (branch, push, PR) use the GitHub MCP server — never `git push`.
+- If the user provides specific commit message or PR title, use those exactly.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,50 +1,78 @@
-# [PROJECT_NAME] Constitution
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+<!-- Sync Impact Report
+  Version change: 0.0.0 (unpopulated template) → 1.0.0 (initial population)
+  Modified principles: N/A (initial population from template placeholders)
+  Added sections:
+    - 7 Principles mapped from docs/CONSTITUTION.md Articles 0–VI
+    - Quality Gates section (Article VI)
+    - Development Workflow section (Article I §1.3)
+    - Governance section (Article VII)
+  Removed sections: None
+  Templates status:
+    - .specify/templates/plan-template.md    ✅ aligned (Constitution Check gate present at L30-34)
+    - .specify/templates/spec-template.md    ✅ aligned (user scenarios + acceptance criteria match §1.2/§2.1)
+    - .specify/templates/tasks-template.md   ✅ aligned (test-first phasing matches §2.1; story-based structure matches §1.3)
+  Follow-up TODOs: None
+-->
+
+# ADE Project Constitution
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+### I. Axiom Acceptance *(Σ.1, Σ.5)*
+Every participant—Human or LLM Agent—MUST read and explicitly accept the ADE Core Axioms before interacting with any project specification or code. Acceptance is a prerequisite for all development activity. Agents MUST acknowledge acceptance in their initial system prompt or session start. Failure to accept the axioms disqualifies the participant from contributing to or modifying the project.
 
-### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+### II. Specification Governance *(Σ.1, Π.1.1, Π.1.2, Π.1.2a)*
+No feature code shall be written without a corresponding specification. Specifications reside in `.specify/specs/{feature-name}/` and MUST include `spec.md` (requirements), `plan.md` (architecture), and `tasks.md` (work breakdown). Violations block PR merge. Specifications MUST follow the Spec-Kit format.
 
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+### III. Deterministic Verification *(Σ.2, Π.2.1, Π.2.1a, Π.2.3a)*
+All features MUST have failing tests before implementation (Red-Green-Refactor). Tests MUST be deterministic and isolated: no external network calls in unit tests, all I/O and external services mocked, all RNGs seeded, no `sleep()`-based timing. Unit suites MUST complete within 60 seconds; integration suites within 5 minutes; E2E suites within 15 minutes.
 
-### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+### IV. Traceable Decision Records *(Σ.3, Π.3.1, Π.3.2, Π.3.2a)*
+Architectural decisions MUST be recorded in ADRs using the MADR format with ADE extensions (Governing Postulate and Axiom Traceability fields). ADRs are required for new components, technology selections, breaking API changes, and security-sensitive changes. ADRs progress through: Proposed → Accepted → Deprecated | Superseded.
 
-### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+### V. Architectural Constraints *(Σ.4, Π.4.1, Π.4.1a, Π.4.1b)*
+Components MUST have a single reason to change. Dependencies MUST flow in one direction (UI → Application → Domain → Infrastructure); circular dependencies are prohibited. Interfaces MUST expose minimal surface area. Breaking interface changes require ADRs.
 
-## [SECTION_2_NAME]
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+### VI. AI Collaboration *(Σ.5, Π.5.1, Π.5.2, Π.5.2a)*
+Repositories MUST provide AI context files: `copilot-instructions.md`, `.gemini.md`, `.claude.md`, and `.specify/memory/constitution.md`. AI agents MUST operate within constitutional constraints, MUST NOT bypass quality gates, MUST escalate after 3 failed strategies (Π.5.3), and MUST produce verification artifacts (screenshots for UI, test output for logic, diff summaries for refactoring).
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+### VII. Coverage Requirements *(Σ.2, Π.2.1)*
+Core business logic MUST maintain ≥80% line coverage. API endpoints MUST have 100% happy-path coverage. Utility functions MUST maintain ≥70% coverage.
 
-## [SECTION_3_NAME]
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+## Quality Gates
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+All PRs MUST pass the following gates before merge:
+
+| Gate     | Tool           | Threshold     |
+| -------- | -------------- | ------------- |
+| Tests    | pytest/vitest  | 100% pass     |
+| Coverage | coverage.py/c8 | ≥80% (core)   |
+| Types    | mypy/tsc       | strict mode   |
+| Lint     | ruff/eslint    | zero errors   |
+| Secrets  | detect-secrets | zero findings |
+
+Branch protection for `main`: require PR reviews (minimum 1), require status checks to pass, prohibit direct pushes, require linear history (squash or rebase).
+
+## Development Workflow
+
+The Spec-Kit lifecycle governs all feature development:
+
+1. `specify` — Define requirements
+2. `clarify` — Resolve ambiguities
+3. `plan` — Design architecture
+4. `tasks` — Create work breakdown
+5. `implement` — Execute tasks
+6. `analyze` — Post-implementation review
 
 ## Governance
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+This constitution supersedes all other practices within the project scope. Amendments follow this process:
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+1. Propose amendment via ADR
+2. Reference the violated or evolved axiom/postulate
+3. Team review period (minimum 3 days)
+4. Ratification by project lead
+
+All PRs and reviews MUST verify constitutional compliance. Complexity MUST be justified via the Complexity Tracking table in `plan.md`. Use `.gemini.md`, `.claude.md`, and `copilot-instructions.md` for runtime development guidance.
+
+**Version**: 1.0.0 | **Ratified**: 2026-02-06 | **Last Amended**: 2026-02-06


### PR DESCRIPTION
## Summary

Populates the `.specify/memory/constitution.md` template, updates agent rules and PR workflow.

### Changes

**`.specify/memory/constitution.md`** — Populated from template to v1.0.0:
- 7 Principles with axiom/postulate traceability (Σ.1–Σ.5)
- Quality Gates, Development Workflow, and Governance sections
- Sync Impact Report embedded as HTML comment

**`.agent/rules/speckit-rules.md`** — Expanded with:
- Constitution, template, axiom, and postulate loading requirements
- Constitutional compliance rules (Quality Gates, test-first, ADRs)

**`.agent/workflows/pr.md`** — Complete 7-step MCP workflow:
- Identify repo, detect changes, create branch, push files, create PR, report

### Validation
- ✅ No remaining bracket tokens in constitution
- ✅ All templates aligned
- ✅ ISO dates, MUST/MUST NOT language throughout