### PR TITLE
feat(us7): CLI for manual checks and blocker GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-python-library.yml
+++ b/.github/workflows/ci-python-library.yml
@@ -43,6 +43,11 @@ jobs:
           source .venv/bin/activate
           mypy src/
 
+      - name: Run ADE Compliance check
+        run: |
+          source .venv/bin/activate
+          ade-compliance check-all src/
+
       - name: Run tests
         run: |
           source .venv/bin/activate

--- a/.github/workflows/compliance-and-security.yml
+++ b/.github/workflows/compliance-and-security.yml
@@ -1,0 +1,69 @@
+name: Compliance and Security
+
+on:
+  workflow_call:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -e .
+          uv pip install detect-secrets pytest pytest-asyncio pytest-cov
+
+      - name: Run ADE Compliance Gate
+        run: |
+          source .venv/bin/activate
+          ade-compliance check-all src/
+
+      - name: Run detect-secrets scan
+        run: |
+          source .venv/bin/activate
+          detect-secrets scan --exclude-files "tests/.*" > detect-secrets-results.json
+          if grep -q '"results": {' detect-secrets-results.json; then
+            echo "FAIL: Hardcoded secrets detected!"
+            cat detect-secrets-results.json
+            exit 1
+          fi
+          echo "No secrets detected."
+
+      - name: Verify commit signatures
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin ${{ github.base_ref }}
+            commits=$(git log origin/${{ github.base_ref }}..HEAD --format="%H")
+          else
+            commits=$(git log -5 --format="%H")
+          fi
+          
+          if [ -z "$commits" ]; then
+            echo "No commits found to verify."
+            exit 0
+          fi
+          
+          echo "Verifying signature status for commits:"
+          for commit in $commits; do
+            echo "Checking commit: $commit"
+            sig_status=$(git log -1 --format="%G?" $commit)
+            echo "Signature status: $sig_status"
+            if [ "$sig_status" != "G" ] && [ "$sig_status" != "U" ]; then
+              echo "FAIL: Commit $commit is not signed or has an invalid signature!"
+              exit 1
+            fi
+          done
+          echo "All commits have valid signatures."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: Continuous Integration & Verification
+
+on:
+  push:
+    branches:
+      - main
+      - 001-ade-compliance
+  pull_request:
+    branches:
+      - main
+      - 001-ade-compliance
+
+jobs:
+  python-ci:
+    name: Python Library Tests & Linting
+    uses: ./.github/workflows/ci-python-library.yml
+    with:
+      python-version: '3.11'
+      coverage-threshold: 80
+
+  compliance-and-security:
+    name: Compliance & Security Verification
+    uses: ./.github/workflows/compliance-and-security.yml

--- a/src/ade_compliance/cli.py
+++ b/src/ade_compliance/cli.py
@@ -1,25 +1,61 @@
 import asyncio
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import click
 
-from ade_compliance.config import load_config
+from ade_compliance.config import load_config, Config
 from ade_compliance.services.orchestrator import Orchestrator
+from ade_compliance.models.report import ComplianceReport
 
 
-@click.group()
-def main():
-    """ADE Compliance Framework CLI"""
-    pass
+def determine_exit_code(violations: List, config: Config) -> int:
+    """Map violations and strictness levels to exit codes:
+    - 0: Compliant (or all violations are 'audit')
+    - 1: Violations detected (at least one 'enforce' strictness)
+    - 2: Warnings detected (no 'enforce', at least one 'warn' strictness)
+    - 3: Internal framework error
+    """
+    if not violations:
+        return 0
+
+    global_strict = config.global_settings.strictness or "warn"
+    has_enforce = False
+    has_warn = False
+
+    for v in violations:
+        axiom_id = v.axiom_id or ""
+        engine_strictness = None
+        if axiom_id.startswith("Π.1"):
+            engine_strictness = config.engines.spec.strictness
+        elif axiom_id.startswith("Π.2"):
+            engine_strictness = config.engines.test.strictness
+        elif axiom_id.startswith("Π.3") or axiom_id.startswith("Π.3.1"):
+            engine_strictness = config.engines.trace.strictness
+
+        strictness = engine_strictness or global_strict
+
+        if strictness == "enforce":
+            has_enforce = True
+        elif strictness == "warn":
+            has_warn = True
+
+    if has_enforce:
+        return 1
+    if has_warn:
+        return 2
+
+    return 0
 
 
-@main.command()
-@click.argument("paths", nargs=-1, type=click.Path(exists=True))
-@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
-def run(paths: List[str], config: str):
-    """Run compliance checks on the specified paths."""
+def _run_checks(
+    paths: List[str],
+    config: str,
+    run_spec: bool = True,
+    run_test: bool = True,
+    run_trace: bool = True,
+) -> Tuple[ComplianceReport, Config]:
     # Expand paths
     files = []
     for p in paths:
@@ -34,10 +70,15 @@ def run(paths: List[str], config: str):
 
     if not files:
         click.echo("No files found to check.")
-        return
+        sys.exit(0)
 
     # Load Config
     cfg = load_config(Path(config))
+
+    # Configure active engines
+    cfg.engines.spec.enabled = cfg.engines.spec.enabled and run_spec
+    cfg.engines.test.enabled = cfg.engines.test.enabled and run_test
+    cfg.engines.trace.enabled = cfg.engines.trace.enabled and run_trace
 
     # Run Orchestrator
     orchestrator = Orchestrator(cfg)
@@ -48,12 +89,64 @@ def run(paths: List[str], config: str):
         click.echo(f"Error running checks: {e}", err=True)
         sys.exit(3)
 
-    # Output Report
-    click.echo(report.generate_summary())
+    return report, cfg
 
-    # Exit code based on violations
+
+@click.group()
+def main():
+    """ADE Compliance Framework CLI"""
+    if sys.platform == "win32":
+        try:
+            sys.stdout.reconfigure(encoding="utf-8")
+            sys.stderr.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+
+
+
+@main.command()
+@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
+def run(paths: List[str], config: str):
+    """Run compliance checks on the specified paths (legacy compatibility)."""
+    report, cfg = _run_checks(paths, config, run_spec=True, run_test=True, run_trace=True)
+    click.echo(report.generate_summary())
     if report.violations:
         sys.exit(1)
+    sys.exit(0)
+
+
+@main.command(name="check-all")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
+def check_all(paths: List[str], config: str):
+    """Run all compliance checks on the specified paths."""
+    report, cfg = _run_checks(paths, config, run_spec=True, run_test=True, run_trace=True)
+    click.echo(report.generate_summary())
+    exit_code = determine_exit_code(report.violations, cfg)
+    sys.exit(exit_code)
+
+
+@main.command(name="check-spec")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
+def check_spec(paths: List[str], config: str):
+    """Run specification compliance checks."""
+    report, cfg = _run_checks(paths, config, run_spec=True, run_test=False, run_trace=False)
+    click.echo(report.generate_summary())
+    exit_code = determine_exit_code(report.violations, cfg)
+    sys.exit(exit_code)
+
+
+@main.command(name="check-test")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
+def check_test(paths: List[str], config: str):
+    """Run test compliance checks."""
+    report, cfg = _run_checks(paths, config, run_spec=False, run_test=True, run_trace=False)
+    click.echo(report.generate_summary())
+    exit_code = determine_exit_code(report.violations, cfg)
+    sys.exit(exit_code)
 
 
 @main.command(name="check-traceability")
@@ -61,28 +154,7 @@ def run(paths: List[str], config: str):
 @click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
 def check_traceability(paths: List[str], config: str):
     """Run traceability checks and generate matrix."""
-    files = []
-    for p in paths:
-        path = Path(p)
-        if path.is_file():
-            files.append(str(path).replace("\\", "/"))
-        elif path.is_dir():
-            for ext in ("*.py", "*.js", "*.ts", "*.tsx", "*.java"):
-                for f in path.rglob(ext):
-                    files.append(str(f).replace("\\", "/"))
-
-    if not files:
-        click.echo("No files found to check.")
-        return
-
-    cfg = load_config(Path(config))
-    orchestrator = Orchestrator(cfg)
-
-    try:
-        report = asyncio.run(orchestrator.run(files))
-    except Exception as e:
-        click.echo(f"Error running traceability checks: {e}", err=True)
-        sys.exit(3)
+    report, cfg = _run_checks(paths, config, run_spec=False, run_test=False, run_trace=True)
 
     # Print Traceability Matrix
     click.echo("\n--- Traceability Matrix ---")
@@ -94,17 +166,69 @@ def check_traceability(paths: List[str], config: str):
             for ltype, targets in links.items():
                 if targets:
                     click.echo(f"  {ltype.capitalize()}: {', '.join(targets)}")
-    
-    # Exit with code based on traceability violations (Π.3.1)
+
     trace_violations = [v for v in report.violations if v.axiom_id == "Π.3.1"]
     if trace_violations:
         click.echo(f"\nFound {len(trace_violations)} traceability violation(s):")
         for v in trace_violations:
             click.echo(f"  - {v.file_path}: {v.message}")
-        sys.exit(1)
-    
+        exit_code = determine_exit_code(trace_violations, cfg)
+        sys.exit(exit_code)
+
     click.echo("\nTraceability check passed successfully!")
     sys.exit(0)
+
+
+@main.command(name="generate-report")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
+def generate_report(paths: List[str], config: str):
+    """Generate machine-readable JSON compliance report."""
+    report, cfg = _run_checks(paths, config, run_spec=True, run_test=True, run_trace=True)
+    report.generate_summary()
+    click.echo(report.model_dump_json(by_alias=True))
+    exit_code = determine_exit_code(report.violations, cfg)
+    sys.exit(exit_code)
+
+
+@main.command(name="override")
+@click.argument("axiom_id")
+@click.option("--scope-type", "-s", type=click.Choice(["FILE", "DIRECTORY", "COMPONENT"]), default="FILE", help="Override scope type")
+@click.option("--scope-value", "-v", required=True, help="File path, directory path, or component name")
+@click.option("--rationale", "-r", required=True, help="Rationale for the override (min 20 characters)")
+@click.option("--created-by", "-b", required=True, help="Architect SSO ID")
+@click.option("--expires-in-days", "-e", type=int, default=90, help="Override expiration in days")
+@click.option("--permanent", is_flag=True, help="Make the override permanent")
+@click.option("--justification", "-j", default="", help="Permanent justification (required if permanent)")
+@click.option("--config", "-c", default=".ade-compliance.yml", help="Path to config file")
+def override(axiom_id, scope_type, scope_value, rationale, created_by, expires_in_days, permanent, justification, config):
+    """Create a compliance violation override."""
+    if len(rationale) < 20:
+        click.echo("Error: Rationale must be at least 20 characters long.", err=True)
+        sys.exit(3)
+    if permanent and not justification:
+        click.echo("Error: Permanent justification is required when is_permanent is True.", err=True)
+        sys.exit(3)
+
+    cfg = load_config(Path(config))
+    from ade_compliance.services.override import OverrideService
+    try:
+        svc = OverrideService(cfg)
+        res = svc.create_override(
+            axiom_id=axiom_id,
+            scope_type=scope_type,
+            scope_value=scope_value,
+            rationale=rationale,
+            created_by=created_by,
+            expires_in_days=expires_in_days,
+            is_permanent=permanent,
+            permanent_justification=justification,
+        )
+        click.echo(f"Override created successfully: ID {res.id}")
+        sys.exit(0)
+    except Exception as e:
+        click.echo(f"Error creating override: {e}", err=True)
+        sys.exit(3)
 
 
 @main.command()
@@ -127,3 +251,4 @@ def serve(host: str, port: int, config: str):
 
 if __name__ == "__main__":
     main()
+

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,5 +1,5 @@
-from unittest.mock import patch
-
+import json
+from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from ade_compliance.cli import main
@@ -7,9 +7,8 @@ from ade_compliance.models.axiom import Violation, ViolationState
 from ade_compliance.models.report import ComplianceReport
 
 
-def test_cli_run_no_violations():
+def test_cli_check_all_no_violations():
     runner = CliRunner()
-    # Mock orchestrator run to return empty report
     with patch("ade_compliance.cli.Orchestrator") as MockOrch:
         instance = MockOrch.return_value
 
@@ -18,29 +17,127 @@ def test_cli_run_no_violations():
 
         instance.run.side_effect = mock_run_empty
 
-        result = runner.invoke(main, ["run", "src/"])
+        result = runner.invoke(main, ["check-all", "src/"])
         assert result.exit_code == 0
         assert "Violations: 0" in result.output
 
 
-def test_cli_run_with_violations():
+def test_cli_check_all_with_violations_warn():
     runner = CliRunner()
     with patch("ade_compliance.cli.Orchestrator") as MockOrch:
         instance = MockOrch.return_value
-        # Use AsyncMock if needed, but Click calls asyncio.run(coro)
-        # So we need instance.run to return a future or be async?
-        # Since we patch the class, instance.run is a Mock.
-        # asyncio.run(mock()) fails if not awaitable.
 
-        # Correctly mock async method
         async def mock_run(*args, **kwargs):
             return ComplianceReport(
                 repo_root=".",
-                violations=[Violation(axiom_id="X.1", file_path="foo.py", message="Fail", state=ViolationState.NEW)],
+                violations=[
+                    Violation(axiom_id="Π.1.1", file_path="foo.py", message="Missing spec", state=ViolationState.NEW)
+                ],
             )
 
         instance.run.side_effect = mock_run
 
-        result = runner.invoke(main, ["run", "src/"])
-        assert result.exit_code == 1
+        result = runner.invoke(main, ["check-all", "src/"])
+        # strictness defaults to warn, so exit code should be 2
+        assert result.exit_code == 2
         assert "Violations: 1" in result.output
+
+
+def test_cli_check_spec_executes():
+    runner = CliRunner()
+    with patch("ade_compliance.cli.Orchestrator") as MockOrch:
+        instance = MockOrch.return_value
+
+        async def mock_run(*args, **kwargs):
+            return ComplianceReport(repo_root=".", violations=[])
+
+        instance.run.side_effect = mock_run
+
+        result = runner.invoke(main, ["check-spec", "src/"])
+        assert result.exit_code == 0
+        assert "Violations: 0" in result.output
+
+
+def test_cli_check_test_executes():
+    runner = CliRunner()
+    with patch("ade_compliance.cli.Orchestrator") as MockOrch:
+        instance = MockOrch.return_value
+
+        async def mock_run(*args, **kwargs):
+            return ComplianceReport(repo_root=".", violations=[])
+
+        instance.run.side_effect = mock_run
+
+        result = runner.invoke(main, ["check-test", "src/"])
+        assert result.exit_code == 0
+        assert "Violations: 0" in result.output
+
+
+def test_cli_check_traceability_executes():
+    runner = CliRunner()
+    with patch("ade_compliance.cli.Orchestrator") as MockOrch:
+        instance = MockOrch.return_value
+
+        async def mock_run(*args, **kwargs):
+            return ComplianceReport(
+                repo_root=".",
+                violations=[],
+                traceability_matrix={"src/foo.py": {"implements": ["Axiom Π.3.1"]}}
+            )
+
+        instance.run.side_effect = mock_run
+
+        result = runner.invoke(main, ["check-traceability", "src/"])
+        assert result.exit_code == 0
+        assert "Traceability Matrix" in result.output
+        assert "Axiom Π.3.1" in result.output
+
+
+def test_cli_generate_report_outputs_json():
+    runner = CliRunner()
+    with patch("ade_compliance.cli.Orchestrator") as MockOrch:
+        instance = MockOrch.return_value
+
+        async def mock_run(*args, **kwargs):
+            return ComplianceReport(
+                repo_root=".",
+                violations=[
+                    Violation(axiom_id="Π.1.1", file_path="foo.py", message="Missing spec", state=ViolationState.NEW)
+                ],
+            )
+
+        instance.run.side_effect = mock_run
+
+        result = runner.invoke(main, ["generate-report", "src/"])
+        assert result.exit_code == 2
+        
+        # Verify output is valid JSON
+        data = json.loads(result.output)
+        assert data["repo_root"] == "."
+        assert "version" in data  # checks alias serialization mapping
+        assert len(data["violations"]) == 1
+
+
+def test_cli_override_creation_success():
+    runner = CliRunner()
+    with patch("ade_compliance.services.override.OverrideService.create_override") as mock_create:
+        mock_res = MagicMock()
+        mock_res.id = "mock-uuid"
+        mock_create.return_value = mock_res
+
+        result = runner.invoke(
+            main,
+            [
+                "override",
+                "Π.1.1",
+                "--scope-value",
+                "src/",
+                "--rationale",
+                "This rationale is long enough to satisfy constraints and validation.",
+                "--created-by",
+                "HA-01",
+            ]
+        )
+        assert result.exit_code == 0
+        assert "Override created successfully" in result.output
+        assert "mock-uuid" in result.output

--- a/tests/unit/test_cli_unit.py
+++ b/tests/unit/test_cli_unit.py
@@ -1,0 +1,112 @@
+import pytest
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from ade_compliance.cli import main, determine_exit_code
+from ade_compliance.models.axiom import Violation, ViolationState
+from ade_compliance.config import Config
+
+
+def test_cli_subcommands_registered():
+    """Verify that all the required subcommands are registered in Click."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "check-all" in result.output
+    assert "check-spec" in result.output
+    assert "check-test" in result.output
+    assert "check-traceability" in result.output
+    assert "generate-report" in result.output
+    assert "override" in result.output
+
+
+@pytest.mark.parametrize(
+    "violations,global_strictness,expected_code",
+    [
+        # No violations -> exit code 0
+        ([], "warn", 0),
+        ([], "enforce", 0),
+        # Violation with global_strictness warn -> exit code 2
+        ([Violation(axiom_id="X.1", file_path="a.py", message="Err")], "warn", 2),
+        # Violation with global_strictness enforce -> exit code 1
+        ([Violation(axiom_id="X.1", file_path="a.py", message="Err")], "enforce", 1),
+    ]
+)
+def test_determine_exit_code_fallback(violations, global_strictness, expected_code):
+    """Test determine_exit_code fallback to global strictness settings."""
+    cfg = Config()
+    cfg.global_settings.strictness = global_strictness
+    cfg.engines.spec.strictness = None
+    cfg.engines.test.strictness = None
+    cfg.engines.trace.strictness = None
+    
+    code = determine_exit_code(violations, cfg)
+    assert code == expected_code
+
+
+def test_determine_exit_code_per_engine():
+    """Test determine_exit_code with different strictness levels per engine."""
+    # Axiom Π.1.1 is SpecEngine (mapped to spec)
+    # Axiom Π.2.1 is TestEngine (mapped to test)
+    # Axiom Π.3.1 is TraceEngine (mapped to trace)
+    v_spec = Violation(axiom_id="Π.1.1", file_path="spec.md", message="Err")
+    v_test = Violation(axiom_id="Π.2.1", file_path="foo.py", message="Err")
+    
+    cfg = Config()
+    cfg.global_settings.strictness = "audit"
+    
+    # 1. Spec is enforce -> exit code 1
+    cfg.engines.spec.strictness = "enforce"
+    cfg.engines.test.strictness = "warn"
+    assert determine_exit_code([v_spec], cfg) == 1
+    
+    # 2. Spec is audit, Test is warn -> exit code 2
+    cfg.engines.spec.strictness = "audit"
+    cfg.engines.test.strictness = "warn"
+    assert determine_exit_code([v_spec, v_test], cfg) == 2
+    
+    # 3. Both are audit -> exit code 0
+    cfg.engines.spec.strictness = "audit"
+    cfg.engines.test.strictness = "audit"
+    assert determine_exit_code([v_spec, v_test], cfg) == 0
+
+
+def test_override_cli_validation_rationale_too_short():
+    """Verify that override command fails when rationale is less than 20 characters."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "override",
+            "Π.1.1",
+            "--scope-value",
+            "src/",
+            "--rationale",
+            "Too short",
+            "--created-by",
+            "HA-01",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Rationale must be at least 20 characters" in result.output
+
+
+def test_override_cli_validation_permanent_requires_justification():
+    """Verify that permanent override requires a justification."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "override",
+            "Π.1.1",
+            "--scope-value",
+            "src/",
+            "--rationale",
+            "This rationale is long enough to pass first check",
+            "--created-by",
+            "HA-01",
+            "--permanent",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Permanent justification is required" in result.output


### PR DESCRIPTION
This pull request implements User Story 7: CLI for Manual Checks, and adds comprehensive blocker GitHub Actions workflows.

### Key Changes
1. **CLI Commands Group**: Added `check-all`, `check-spec`, `check-test`, `generate-report`, and `override` commands.
2. **Strict Exit Codes**: Maps violations/warnings to `0`, `1`, `2`, or `3` depending on strictness.
3. **Blocker GitHub Actions Workflows**:
   - `main.yml`: Orchestrates CI runs on push and PR.
   - `compliance-and-security.yml`: Enforces GHA blocker-status checking on automated compliance, credential leaks (`detect-secrets`), and PR commit signature verification.
4. **Encoding hardiness**: Added standard Windows terminal stdout encoding reconfig.
5. **Testing**: Comprehensive tests added under `tests/unit/test_cli_unit.py` and `tests/integration/test_cli.py`.

Closes #31