### PR TITLE
feat(adr): implement ADR Detection Engine to enforce postulate Π.3.1

### DIFF
--- a/src/ade_compliance/config.py
+++ b/src/ade_compliance/config.py
@@ -25,6 +25,7 @@ class Engines(BaseModel):
     spec: EngineConfig = EngineConfig()
     test: EngineConfig = EngineConfig()
     trace: EngineConfig = Field(default_factory=EngineConfig, alias="traceability")
+    adr: EngineConfig = EngineConfig()
 
     model_config = {"extra": "ignore"}
 

--- a/src/ade_compliance/engines/adr_engine.py
+++ b/src/ade_compliance/engines/adr_engine.py
@@ -1,0 +1,82 @@
+import subprocess
+from pathlib import Path
+from typing import List
+
+from ..models.axiom import Violation, ViolationState
+from .base import BaseEngine
+
+
+class ADREngine(BaseEngine):
+    """Engine to enforce postulate Π.3.1 (ADRs required for all architectural changes)."""
+
+    async def check(self, files: List[str]) -> List[Violation]:
+        if not self.should_run():
+            return []
+
+        violations = []
+
+        # Heuristic for detecting architectural files
+        architectural_files = []
+        adr_files = []
+
+        for f in files:
+            path_str = f.replace("\\", "/").strip("/")
+            
+            # 1. Standard config/meta architectural files
+            if path_str in ("pyproject.toml", ".ade-compliance.yml", "setup.py"):
+                architectural_files.append(f)
+            
+            # 2. Structural models and engines changes
+            elif path_str.startswith("src/ade_compliance/models/") or path_str.startswith("src/ade_compliance/engines/"):
+                architectural_files.append(f)
+
+            # 3. Detect changes in ADR directory
+            elif path_str.startswith("docs/decisions/") and path_str.endswith(".md"):
+                adr_files.append(f)
+
+        # If there are architectural modifications but no corresponding ADR file in checked list
+        if architectural_files and not adr_files:
+            violations.append(
+                Violation(
+                    axiom_id="Π.3.1",
+                    file_path=architectural_files[0],
+                    message=(
+                        f"Architectural change detected in '{architectural_files[0]}', "
+                        f"but no ADR created or modified under 'docs/decisions/'. "
+                        f"Postulate Π.3.1 requires recording ADRs for all architectural changes."
+                    ),
+                    state=ViolationState.NEW,
+                )
+            )
+            return violations
+
+        # If an ADR is added/modified, or if we want to run checks on the whole repo
+        # Execute pyadr validation using subprocess to guarantee format sanity
+        if adr_files:
+            try:
+                # Run check-adr-repo from pyadr
+                res = subprocess.run(["pyadr", "check-adr-repo"], capture_output=True, text=True)
+                if res.returncode != 0:
+                    violations.append(
+                        Violation(
+                            axiom_id="Π.3.2",
+                            file_path=adr_files[0],
+                            message=(
+                                f"pyadr check-adr-repo failed on the ADR repository.\n"
+                                f"Error Details:\n{res.stderr or res.stdout}"
+                            ),
+                            state=ViolationState.NEW,
+                        )
+                    )
+            except Exception as e:
+                # If pyadr command itself fails/not found, log it as format violation
+                violations.append(
+                    Violation(
+                        axiom_id="Π.3.2",
+                        file_path=adr_files[0],
+                        message=f"Error executing pyadr validation check: {e}",
+                        state=ViolationState.NEW,
+                    )
+                )
+
+        return violations

--- a/src/ade_compliance/services/orchestrator.py
+++ b/src/ade_compliance/services/orchestrator.py
@@ -27,6 +27,10 @@ class Orchestrator:
         else:
             self.trace_engine = None
 
+        if hasattr(self.config.engines, "adr") and self.config.engines.adr.enabled:
+            from ..engines.adr_engine import ADREngine
+            self.engines.append(ADREngine(self.config.engines.adr))
+
     async def run(self, files: List[str]) -> ComplianceReport:
         all_violations = []
 

--- a/tests/unit/engines/test_adr_engine.py
+++ b/tests/unit/engines/test_adr_engine.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ade_compliance.config import EngineConfig
+from ade_compliance.engines.adr_engine import ADREngine
+from ade_compliance.models.axiom import ViolationState
+
+
+def test_adr_engine_disabled():
+    """Verify that the engine does nothing and returns empty list when disabled."""
+    config = EngineConfig(enabled=False)
+    engine = ADREngine(config)
+    
+    assert not engine.should_run()
+    # Execute check synchronously in testing since we are in async pytest
+    # and engines use async check(...) methods
+    # We will await it using a simple event loop run
+    import asyncio
+    violations = asyncio.run(engine.check(["pyproject.toml"]))
+    assert violations == []
+
+
+def test_adr_engine_no_architectural_changes():
+    """Verify that standard changes (e.g. non-architectural source code) do not trigger violations."""
+    config = EngineConfig(enabled=True)
+    engine = ADREngine(config)
+    
+    import asyncio
+    violations = asyncio.run(engine.check(["src/ade_compliance/services/audit.py", "tests/unit/test_config.py"]))
+    assert violations == []
+
+
+def test_adr_engine_architectural_change_without_adr():
+    """Verify that changing an architectural file without a corresponding ADR raises a Π.3.1 violation."""
+    config = EngineConfig(enabled=True)
+    engine = ADREngine(config)
+    
+    import asyncio
+    # pyproject.toml is an architectural file
+    violations = asyncio.run(engine.check(["pyproject.toml", "src/ade_compliance/cli.py"]))
+    assert len(violations) == 1
+    assert violations[0].axiom_id == "Π.3.1"
+    assert violations[0].state == ViolationState.NEW
+    assert "no ADR created or modified" in violations[0].message
+
+
+@patch("subprocess.run")
+def test_adr_engine_architectural_change_with_adr_success(mock_run):
+    """Verify that changing an architectural file along with an ADR passes successfully if pyadr passes."""
+    mock_res = MagicMock()
+    mock_res.returncode = 0
+    mock_run.return_value = mock_res
+    
+    config = EngineConfig(enabled=True)
+    engine = ADREngine(config)
+    
+    import asyncio
+    violations = asyncio.run(engine.check(["pyproject.toml", "docs/decisions/0002-test.md"]))
+    assert violations == []
+    mock_run.assert_called_once_with(["pyadr", "check-adr-repo"], capture_output=True, text=True)
+
+
+@patch("subprocess.run")
+def test_adr_engine_architectural_change_with_adr_failure(mock_run):
+    """Verify that if pyadr validation fails, a Π.3.2 violation is raised."""
+    mock_res = MagicMock()
+    mock_res.returncode = 1
+    mock_res.stderr = "Validation error: invalid status"
+    mock_run.return_value = mock_res
+    
+    config = EngineConfig(enabled=True)
+    engine = ADREngine(config)
+    
+    import asyncio
+    violations = asyncio.run(engine.check(["pyproject.toml", "docs/decisions/0002-test.md"]))
+    assert len(violations) == 1
+    assert violations[0].axiom_id == "Π.3.2"
+    assert "pyadr check-adr-repo failed" in violations[0].message
+    assert "Validation error" in violations[0].message
+
+
+def test_orchestrator_loads_adr_engine():
+    """Verify that the Orchestrator initializes ADREngine when configured."""
+    from ade_compliance.services.orchestrator import Orchestrator
+    from ade_compliance.config import Config
+    cfg = Config()
+    cfg.engines.adr.enabled = True
+    
+    orch = Orchestrator(cfg)
+    loaded_types = [type(e).__name__ for e in orch.engines]
+    assert "ADREngine" in loaded_types
+


### PR DESCRIPTION
This pull request implements the ADR Detection Engine (Phase 11 / Issue #33) to enforce postulate Π.3.1.

### Key Changes
1. **ADR Engine (`adr_engine.py`)**: Added an ADR scanner checking for architectural files modified/added in the codebase. Raises a Π.3.1 violation if core structural changes are made without updating ADR files. Runs `pyadr check-adr-repo` to validate the ADR directory and captures failures to raise Π.3.2 violations.
2. **Orchestrator Registration (`orchestrator.py`)**: Registered `ADREngine` into the compliance execution flow, keeping backward compatibility with hasattr config checking.
3. **Config Expansion (`config.py`)**: Added `adr` EngineConfig field mapping.
4. **Unit and Integration Testing (`test_adr_engine.py`)**: Comprehensive test suite capturing all compliance and failure validation flows. All tests pass successfully.

Closes #33