### PR TITLE
chore(ci): restore setup-python version back to stable v5

### DIFF
--- a/.github/workflows/ci-python-library.yml
+++ b/.github/workflows/ci-python-library.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/ci-python-service.yml
+++ b/.github/workflows/ci-python-service.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
Restores `actions/setup-python` back to stable `v5` (since `v6` does not exist and broke all library/service CI workflows on the `main` branch).