### PR TITLE
chore(ci): bump checkout, setup-uv, and codecov action versions in workflows

### DIFF
--- a/.github/workflows/ci-python-library.yml
+++ b/.github/workflows/ci-python-library.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: |
@@ -54,7 +54,7 @@ jobs:
           pytest --cov=src --cov-report=xml --cov-fail-under=${{ inputs.coverage-threshold }}
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/ci-python-service.yml
+++ b/.github/workflows/ci-python-service.yml
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.deploy && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/compliance-and-security.yml
+++ b/.github/workflows/compliance-and-security.yml
@@ -7,7 +7,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch full history for revert capabilities
 
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/specs-gate.yml
+++ b/.github/workflows/specs-gate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for diff checks
 


### PR DESCRIPTION
Bumps the versions of actions across all CI/CD pipelines to their latest secure, stable major tags: actions/checkout to \6\, astral-sh/setup-uv to \8.1.0\, and codecov/codecov-action to \5\.