### PR TITLE
fix(ci): support GitHub Merge Queue via merge_group trigger

### DIFF
--- a/.github/scripts/verify_commits.py
+++ b/.github/scripts/verify_commits.py
@@ -7,6 +7,8 @@ CONVENTIONAL_REGEX = re.compile(
 )
 
 def verify_commits(base_ref="main"):
+    if base_ref.startswith("refs/heads/"):
+        base_ref = base_ref[len("refs/heads/"):]
     try:
         subprocess.run(["git", "fetch", "origin", base_ref], check=True, capture_output=True)
         result = subprocess.run(

--- a/.github/scripts/verify_pr_size.py
+++ b/.github/scripts/verify_pr_size.py
@@ -3,6 +3,8 @@ import sys
 
 
 def verify_pr_size(base_ref="main", limit=200):
+    if base_ref.startswith("refs/heads/"):
+        base_ref = base_ref[len("refs/heads/"):]
     try:
         # Fetch base ref first to ensure it's available
         subprocess.run(["git", "fetch", "origin", base_ref], check=True, capture_output=True)

--- a/.github/workflows/commit-message-linter.yml
+++ b/.github/workflows/commit-message-linter.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 001-ade-compliance
+  merge_group:
 
 permissions:
   contents: read
@@ -26,6 +27,6 @@ jobs:
 
       - name: Run Commit Message Verifier
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: |
           python .github/scripts/verify_commits.py --base "$BASE_REF"

--- a/.github/workflows/compliance-and-security.yml
+++ b/.github/workflows/compliance-and-security.yml
@@ -50,9 +50,10 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: |
+          CLEAN_BASE_REF="${BASE_REF#refs/heads/}"
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "merge_group" ]; then
-            git fetch origin "$BASE_REF"
-            commits=$(git log origin/"$BASE_REF"..HEAD --since="2026-05-20" --no-merges --format="%H")
+            git fetch origin "$CLEAN_BASE_REF"
+            commits=$(git log origin/"$CLEAN_BASE_REF"..HEAD --since="2026-05-20" --no-merges --format="%H")
           else
             commits=$(git log -5 --no-merges --format="%H")
           fi

--- a/.github/workflows/compliance-and-security.yml
+++ b/.github/workflows/compliance-and-security.yml
@@ -48,9 +48,9 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "merge_group" ]; then
             git fetch origin "$BASE_REF"
             commits=$(git log origin/"$BASE_REF"..HEAD --since="2026-05-20" --no-merges --format="%H")
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 001-ade-compliance
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/pr-size-gate.yml
+++ b/.github/workflows/pr-size-gate.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 001-ade-compliance
+  merge_group:
 
 permissions:
   contents: read
@@ -26,6 +27,6 @@ jobs:
 
       - name: Run PR Size Verifier
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: |
           python .github/scripts/verify_pr_size.py --base "$BASE_REF" --limit 200

--- a/.github/workflows/specs-gate.yml
+++ b/.github/workflows/specs-gate.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - 'specs/**'
+  merge_group:
+    paths:
+      - 'specs/**'
 
 permissions:
   contents: read
@@ -21,7 +24,7 @@ jobs:
       - name: Validate changed Spec-Kit folders
         shell: bash
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: |
           echo "Checking for changed directories under specs/..."
           

--- a/.github/workflows/specs-gate.yml
+++ b/.github/workflows/specs-gate.yml
@@ -26,10 +26,11 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
         run: |
+          CLEAN_BASE_REF="${BASE_REF#refs/heads/}"
           echo "Checking for changed directories under specs/..."
           
           # Get list of changed files under specs/
-          changed_files=$(git diff --name-only origin/"$BASE_REF"...HEAD | grep '^specs/' || true)
+          changed_files=$(git diff --name-only origin/"$CLEAN_BASE_REF"...HEAD | grep '^specs/' || true)
           
           if [ -z "$changed_files" ]; then
             echo "No specification files found in the pull request diff."


### PR DESCRIPTION
Enables `merge_group` event triggers on all gating CI workflows so that required status checks can run and pass on temporary merge group branches when a pull request is placed in the merge queue. Also updates baseline reference resolution (`BASE_REF`) to handle merge groups safely.