### PR TITLE
Fix for Assignment to constant

### DIFF
--- a/web-portal/script.js
+++ b/web-portal/script.js
@@ -229,11 +229,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Mobile navigation toggle
     const navToggle = document.querySelector('.nav-toggle');
-    const navLinks = document.querySelector('.nav-links');
+    const navLinksContainer = document.querySelector('.nav-links');
 
     if (navToggle) {
         navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('active');
+            navLinksContainer.classList.toggle('active');
         });
     }
 


### PR DESCRIPTION
To fix this without changing functionality, keep both constants but give them different names based on what they represent:

- Keep `const navLinks = document.querySelectorAll('.nav-link');` for the collection used by active-link-on-scroll logic.
- Rename the mobile menu container variable at line 232 from `navLinks` to something like `navLinksContainer`.
- Update the click handler at line 236 to toggle `navLinksContainer`.

This is a minimal, behavior-preserving fix in `web-portal/script.js` within the `DOMContentLoaded` listener. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._