### PR TITLE
ci(codeql): resolve trigger conflict with default setup on main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,7 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
-  schedule:
-    - cron: '30 1 * * 0'
+  workflow_dispatch:
 
 permissions:
   actions: read


### PR DESCRIPTION
This PR disables automatic (push, schedule) triggers in the custom CodeQL workflow since GitHub's Default Setup is enabled on the repository. This prevents CodeQL failures on push to main.